### PR TITLE
Update lib.py to fix #901

### DIFF
--- a/backtesting/lib.py
+++ b/backtesting/lib.py
@@ -138,6 +138,7 @@ def plot_heatmaps(heatmap: pd.Series,
     [plot_objective]: \
         https://scikit-optimize.github.io/stable/modules/plots.html#plot-objective
     """
+    assert heatmap.index.nlevels >= 2, "Heatmap plots requires at least 2 optimized parameters."
     return _plot_heatmaps(heatmap, agg, ncols, filename, plot_width, open_browser)
 
 


### PR DESCRIPTION
Heatmap plots requires at least two parameters (variables) in the heatmap Series.  Add an assert before calling _plot_heatmap to guard against the case of having only 1 variable.